### PR TITLE
Fix CI Azure Docker cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
         with:
           azcliversion: 2.27.2 # v2.28.0 introduces regression https://github.com/Azure/azure-cli/issues/19489
           inlinescript: |
-            $ignore = az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-sql-server.outputs.sqlinstance }} --yes
+            az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-sql-server.outputs.sqlinstance }} --yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
           dotnet test src --configuration Release --no-build --framework net5.0 --logger "GitHubActions;report-warnings=false" -m:1
       - name: Teardown SQL Server
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          $ignore = az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-sql-server.outputs.sqlinstance }} --yes
+        uses: azure/CLI@1.0.4
+        with:
+          azcliversion: 2.27.2 # v2.28.0 introduces regression https://github.com/Azure/azure-cli/issues/19489
+          inlinescript: |
+            $ignore = az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-sql-server.outputs.sqlinstance }} --yes


### PR DESCRIPTION
Version 2.28.0 of the Azure CLI introduces [a bug](https://github.com/Azure/azure-cli/issues/19489) that prevents deletion of containers.

This PR locks the build to an older version of the CLI just before the bug was introduced.