### PR TITLE
Fix CI Azure Docker cleanup by switching to powershell action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
           dotnet test src --configuration Release --no-build --framework net5.0 --logger "GitHubActions;report-warnings=false" -m:1
       - name: Teardown SQL Server
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          $ignore = az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-sql-server.outputs.sqlinstance }} --yes
+        uses: Azure/powershell@v1
+        with:
+          inlineScript: Remove-AzContainerGroup -ResourceGroupName GitHubActions-RG -Name ${{ steps.setup-sql-server.outputs.sqlinstance }}
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,4 +97,4 @@ jobs:
         uses: Azure/powershell@v1
         with:
           inlineScript: Remove-AzContainerGroup -ResourceGroupName GitHubActions-RG -Name ${{ steps.setup-sql-server.outputs.sqlinstance }}
-          
+          azPSVersion: 6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         uses: azure/login@v1.3.0
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+          enable-AzPSSession: true
       - name: Setup SQL Server
         id: setup-sql-server
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
         uses: Azure/powershell@v1
         with:
           inlineScript: Remove-AzContainerGroup -ResourceGroupName GitHubActions-RG -Name ${{ steps.setup-sql-server.outputs.sqlinstance }}
-          azPSVersion: 6.4.0
+          azPSVersion: latest


### PR DESCRIPTION
Version 2.28.0 of the Azure CLI introduces [a bug](https://github.com/Azure/azure-cli/issues/19489) that prevents deletion of containers.

This PR switches to the powershell module to perform the cleanup